### PR TITLE
add configuration info for Z1 device

### DIFF
--- a/platform/z1/contiki-conf.h
+++ b/platform/z1/contiki-conf.h
@@ -180,11 +180,13 @@
 
 /* Handle 10 neighbors */
 #ifndef NBR_TABLE_CONF_MAX_NEIGHBORS
+// when buffer overflow happens, can reduce number of neighbors
 #define NBR_TABLE_CONF_MAX_NEIGHBORS    6
 #endif
 
 /* Handle 10 routes    */
 #ifndef UIP_CONF_MAX_ROUTES
+// To reduce buffer overflow, have to reduce number of routing times
 #define UIP_CONF_MAX_ROUTES             6
 #endif
 


### PR DESCRIPTION
When current config is used for Z1 device, buffer overflow happens. 
For that need to change configuration 